### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Description
+
+<!-- What happened? -->
+
+## Steps to reproduce
+
+1.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Environment
+
+- Go version:
+- Module version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new feature
+labels: enhancement
+---
+
+## Description
+
+<!-- What would you like to see added? -->
+
+## Use case
+
+<!-- Why is this needed? What problem does it solve? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+Closes #
+
+## Changes
+
+<!-- Bulleted list of key changes -->
+
+-
+
+## Test plan
+
+<!-- How were these changes tested? -->
+
+- [ ] `golangci-lint run` passes
+- [ ] `go test ./...` passes
+- [ ] `go build ./...` passes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

Adds standard GitHub PR template, issue templates (bug report and feature request), and Dependabot configuration adapted for a Go module.

Closes #17

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — PR template with Go-specific test checklist
- `.github/ISSUE_TEMPLATE/bug_report.md` — Bug report template with Go/module version fields
- `.github/ISSUE_TEMPLATE/feature_request.md` — Feature request template (language-agnostic)
- `.github/dependabot.yml` — Dependabot config for `gomod` and `github-actions` ecosystems

## Test plan

- [ ] `golangci-lint run` passes
- [ ] `go test ./...` passes
- [ ] `go build ./...` passes