### PR TITLE
chore: set up Go library project structure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gofmt
+    - goimports

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jrrembert/go-luhn
+
+go 1.21

--- a/luhn.go
+++ b/luhn.go
@@ -1,0 +1,41 @@
+// Package luhn implements the Luhn algorithm (ISO/IEC 7812-1) for generating
+// and validating checksums used in credit card numbers, IMEI numbers, and more.
+package luhn
+
+// Generate calculates and appends a Luhn check digit to value.
+// If checksumOnly is true, only the check digit is returned.
+// Returns an error if value fails input validation.
+func Generate(value string, checksumOnly bool) (string, error) {
+	return "", nil
+}
+
+// Validate determines whether value has a valid Luhn check digit as its last character.
+// Returns an error if value fails input validation or has length 1.
+func Validate(value string) (bool, error) {
+	return false, nil
+}
+
+// Random generates a random numeric string of the given length (as a numeric string)
+// with a valid Luhn check digit. The first digit is never zero.
+// Returns an error if length fails input validation or is out of range [2, 100].
+func Random(length string) (string, error) {
+	return "", nil
+}
+
+// GenerateModN computes a Luhn mod-N check character for the given alphanumeric value.
+// n must be between 1 and 36. If checksumOnly is true, only the check character is returned.
+func GenerateModN(value string, n int, checksumOnly bool) (string, error) {
+	return "", nil
+}
+
+// ValidateModN determines whether value has a valid Luhn mod-N check character.
+// n must be between 1 and 36.
+func ValidateModN(value string, n int) (bool, error) {
+	return false, nil
+}
+
+// ChecksumModN returns the integer index of the Luhn mod-N check character for value.
+// n must be between 1 and 36.
+func ChecksumModN(value string, n int) (int, error) {
+	return 0, nil
+}

--- a/luhn_test.go
+++ b/luhn_test.go
@@ -1,0 +1,40 @@
+package luhn_test
+
+import (
+	"testing"
+
+	luhn "github.com/jrrembert/go-luhn"
+)
+
+// TestPackageExports verifies the package compiles and all 6 public functions are exported.
+func TestPackageExports(t *testing.T) {
+	// Generate
+	if _, err := luhn.Generate("1", false); err != nil {
+		t.Logf("Generate returned error (stub not yet implemented): %v", err)
+	}
+
+	// Validate
+	if _, err := luhn.Validate("18"); err != nil {
+		t.Logf("Validate returned error (stub not yet implemented): %v", err)
+	}
+
+	// Random
+	if _, err := luhn.Random("4"); err != nil {
+		t.Logf("Random returned error (stub not yet implemented): %v", err)
+	}
+
+	// GenerateModN
+	if _, err := luhn.GenerateModN("1", 10, false); err != nil {
+		t.Logf("GenerateModN returned error (stub not yet implemented): %v", err)
+	}
+
+	// ValidateModN
+	if _, err := luhn.ValidateModN("18", 10); err != nil {
+		t.Logf("ValidateModN returned error (stub not yet implemented): %v", err)
+	}
+
+	// ChecksumModN
+	if _, err := luhn.ChecksumModN("1", 10); err != nil {
+		t.Logf("ChecksumModN returned error (stub not yet implemented): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Converts the stub Go project into a proper importable library package, establishing the foundation for all algorithm implementations.

Closes #3

## Changes

- Change `package main` to `package luhn`
- Update module path from `jrrembert/go-luhn` to `github.com/jrrembert/go-luhn`
- Update Go version from 1.19 to 1.21
- Remove demo dependency `rsc.io/quote` (no external dependencies needed)
- Add exported stubs for all 6 public API functions: `Generate`, `Validate`, `Random`, `GenerateModN`, `ValidateModN`, `ChecksumModN`
- Add `luhn_test.go` with package export verification test
- Add `.golangci.yml` linting configuration

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] All 6 public functions are exported and callable