### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main, rc]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.21", "1.22"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - run: go vet ./...
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+      - run: go build ./...
+      - run: go test -count=1 -race -coverprofile=coverage.out ./...
+      - uses: codecov/codecov-action@v4
+        if: matrix.go-version == '1.22'
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-luhn
 
+[![CI](https://github.com/jrrembert/go-luhn/actions/workflows/ci.yml/badge.svg)](https://github.com/jrrembert/go-luhn/actions/workflows/ci.yml)
+
 A minimal, dependency-free Go library implementing the [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) (ISO/IEC 7812-1) for generating and validating checksums. Commonly used for credit card validation, IMEI numbers, and other numeric identifiers.
 
 ## Installation


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI workflow that runs linting, vetting, building, and testing on every push and PR targeting `main` or `rc`.

Closes #18

## Changes

- Add `.github/workflows/ci.yml` with Go version matrix (`1.21`, `1.22`)
- Steps: checkout, setup-go, `go vet`, golangci-lint, `go build`, `go test` with race detector and coverage
- Upload coverage to Codecov from the `1.22` matrix leg
- Add CI status badge to `README.md`

## Test plan

- [x] CI workflow runs on this PR
- [x] Both Go `1.21` and `1.22` matrix legs pass
- [x] `go vet`, `golangci-lint`, `go build`, and `go test` steps all succeed
- [ ] Codecov upload step runs on the `1.22` leg