### PR TITLE
feat: implement Generate function

### DIFF
--- a/luhn.go
+++ b/luhn.go
@@ -41,6 +41,31 @@ func validateInput(value string) error {
 	return nil
 }
 
+// generateChecksum computes the Luhn check digit for a numeric string.
+func generateChecksum(value string) byte {
+	sum := 0
+	shouldDouble := true
+
+	for i := len(value) - 1; i >= 0; i-- {
+		digit := int(value[i] - '0')
+
+		if shouldDouble {
+			doubled := digit * 2
+			if doubled >= 10 {
+				sum += doubled/10 + doubled%10
+			} else {
+				sum += doubled
+			}
+		} else {
+			sum += digit
+		}
+		shouldDouble = !shouldDouble
+	}
+
+	checkDigit := (10 - (sum % 10)) % 10
+	return byte('0' + checkDigit)
+}
+
 // Generate calculates and appends a Luhn check digit to value.
 // If checksumOnly is true, only the check digit is returned.
 // Returns an error if value fails input validation.
@@ -48,7 +73,12 @@ func Generate(value string, checksumOnly bool) (string, error) {
 	if err := validateInput(value); err != nil {
 		return "", err
 	}
-	return "", nil
+
+	check := generateChecksum(value)
+	if checksumOnly {
+		return string(check), nil
+	}
+	return value + string(check), nil
 }
 
 // Validate determines whether value has a valid Luhn check digit as its last character.

--- a/luhn_test.go
+++ b/luhn_test.go
@@ -41,6 +41,92 @@ func TestPackageExports(t *testing.T) {
 	}
 }
 
+// TestGenerateChecksumOnly tests Generate with checksumOnly=true against SPEC.md §5 test vectors.
+func TestGenerateChecksumOnly(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1", "8"},
+		{"12", "5"},
+		{"123", "0"},
+		{"1234", "4"},
+		{"12345", "5"},
+		{"123456", "6"},
+		{"1234567", "4"},
+		{"12345678", "2"},
+		{"123456789", "7"},
+		{"7992739871", "3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := luhn.Generate(tt.input, true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Generate(%q, true) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGenerateFullOutput tests Generate with checksumOnly=false against SPEC.md §5 test vectors.
+func TestGenerateFullOutput(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1", "18"},
+		{"12", "125"},
+		{"123", "1230"},
+		{"1234", "12344"},
+		{"12345", "123455"},
+		{"123456", "1234566"},
+		{"1234567", "12345674"},
+		{"12345678", "123456782"},
+		{"123456789", "1234567897"},
+		{"7992739871", "79927398713"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := luhn.Generate(tt.input, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Generate(%q, false) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGenerateEdgeCases tests Generate edge cases from SPEC.md §5.
+func TestGenerateEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"leading zero", "0", "00"},
+		{"multiple leading zeros", "00123", "001230"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := luhn.Generate(tt.input, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Generate(%q, false) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestSharedValidation tests the shared validation errors through Generate, Validate, and Random.
 // Each error case is tested through all three functions to confirm they share the same validation.
 func TestSharedValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

Implement the `Generate` function — the core Luhn algorithm that appends a check digit to a numeric string.

Closes #6

## Changes

- Add unexported `generateChecksum(value string) byte` implementing the Luhn doubling algorithm from SPEC.md §3
- Wire `generateChecksum` into `Generate`, supporting both `checksumOnly=true` (returns check digit only) and `checksumOnly=false` (returns value + check digit)
- Preserves leading zeros as required by spec

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (59 test cases)
- [x] `go build ./...` passes
- [x] `TestGenerateChecksumOnly` — 10 spec vectors for checksum-only mode
- [x] `TestGenerateFullOutput` — 10 spec vectors for full output mode
- [x] `TestGenerateEdgeCases` — leading zero and multiple leading zeros

🤖 Generated with [Claude Code](https://claude.com/claude-code)