### PR TITLE
feat: implement Validate function

### DIFF
--- a/luhn.go
+++ b/luhn.go
@@ -90,7 +90,13 @@ func Validate(value string) (bool, error) {
 	if len(value) == 1 {
 		return false, errMinLength
 	}
-	return false, nil
+
+	payload := value[:len(value)-1]
+	generated, err := Generate(payload, false)
+	if err != nil {
+		return false, err
+	}
+	return generated == value, nil
 }
 
 // Random generates a random numeric string of the given length (as a numeric string)

--- a/luhn_test.go
+++ b/luhn_test.go
@@ -126,6 +126,53 @@ func TestGenerateEdgeCases(t *testing.T) {
 	}
 }
 
+// TestValidateValid tests Validate with valid checksums from SPEC.md §5.
+func TestValidateValid(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{"18"},
+		{"125"},
+		{"1230"},
+		{"001230"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := luhn.Validate(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got {
+				t.Errorf("Validate(%q) = false, want true", tt.input)
+			}
+		})
+	}
+}
+
+// TestValidateInvalid tests Validate with invalid checksums from SPEC.md §5.
+func TestValidateInvalid(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{"10"},
+		{"120"},
+		{"1231"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := luhn.Validate(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got {
+				t.Errorf("Validate(%q) = true, want false", tt.input)
+			}
+		})
+	}
+}
+
 // TestSharedValidation tests the shared validation errors through Generate, Validate, and Random.
 // Each error case is tested through all three functions to confirm they share the same validation.
 func TestSharedValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

Implement the `Validate` function — verifies that a string passes the Luhn check by calling `Generate` on the payload and comparing results.

Closes #7

## Changes

- Implement `Validate`: strip last character, call `Generate` on remainder, compare to original
- Add `TestValidateValid` — 4 spec vectors including leading zeros
- Add `TestValidateInvalid` — 3 spec vectors for wrong check digits

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (66 test cases)
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)