### PR TITLE
ci: register new releases with Go module proxy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,16 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Register with Go module proxy
+        run: |
+          git fetch --tags
+          VERSION=$(git tag --points-at HEAD | head -1)
+          if [ -n "$VERSION" ]; then
+            echo "Registering $VERSION with Go module proxy..."
+            GOPROXY=https://proxy.golang.org go list -m "github.com/jrrembert/go-luhn@$VERSION"
+          else
+            echo "No new tag created, skipping proxy registration."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Releases are fully automated via [semantic-release](https://github.com/semantic-
 - **Release candidates**: Push `feat:`/`fix:` commits to the `rc` branch → publishes pre-release versions (e.g., `1.0.0-rc.1`)
 - **Stable releases**: Merge `rc` into `main` → publishes stable versions (e.g., `1.0.0`)
 - Every stable release must be preceded by at least one release candidate
+- After each release, the workflow automatically registers the new version with the [Go module proxy](https://proxy.golang.org) so it's immediately discoverable on [pkg.go.dev](https://pkg.go.dev/github.com/jrrembert/go-luhn) and available via `go get`
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Adds a post-release step to the release workflow that pings `proxy.golang.org` so new versions are immediately discoverable on [pkg.go.dev](https://pkg.go.dev/github.com/jrrembert/go-luhn) and available via `go get`.

Closes #51

## Changes

- **`.github/workflows/release.yml`**: Added `setup-go` and a "Register with Go module proxy" step after `semantic-release`. It detects the newly created tag (if any) and runs `go list -m` against the proxy to trigger indexing.
- **`CLAUDE.md`**: Documented the automatic proxy registration in the Releases section.

## Test plan

- [ ] Verify workflow YAML is valid (CI will check this)
- [ ] On next release, confirm the new version appears on [proxy.golang.org](https://proxy.golang.org/github.com/jrrembert/go-luhn/@v/list) shortly after the workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)