### PR TITLE
docs: document merge strategy for release PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,9 @@ Releases are fully automated via [semantic-release](https://github.com/semantic-
 - Branch naming: use prefixes `feature/`, `fix/`, `chore/` (e.g., `feature/add-auth`, `fix/login-bug`)
 - Commits, PR titles, and issue titles follow conventional commit format: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `ci:`
 - Always merge PRs via GitHub UI or `gh pr merge` — never merge locally with `git merge` then push. Local merges break GitHub's `Closes #N` auto-close linking.
+- **Merge strategy**:
+  - `--rebase` for all regular PRs: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `ci:`
+  - `--merge` (merge commit) for release PRs (`rc` → `main`) — keeps the branches in sync and avoids SHA divergence
 - PRs use the template at `.github/PULL_REQUEST_TEMPLATE.md` — fill in all sections (Summary, Changes, Test plan)
 - Use `/pr` or `/pr <issue-number>` to create pull requests with the standard format
 - Always create the feature branch from the appropriate base branch (`rc` for features/fixes, `main` for chore/docs) **before** writing code, not at commit time

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -29,6 +29,8 @@ When `rc` is merged into `main`, semantic-release:
 2. Creates a git tag (e.g., `v1.0.0`)
 3. Creates a GitHub Release with auto-generated release notes
 
+**Important**: Release PRs (`rc` → `main`) must use **merge commits** (`gh pr merge --merge`), not rebase. Rebase replays commits with new SHAs, causing `rc` and `main` to diverge and requiring a sync step after every release. Merge commits preserve the shared history between branches.
+
 Go module consumers can then install the stable version:
 
 ```bash


### PR DESCRIPTION
## Summary

Document that release PRs (rc → main) must use merge commits while all other PRs use rebase. This prevents SHA divergence between branches after each release.

Closes #50

## Changes

- Update `CLAUDE.md` Git Workflow section with merge strategy guidance for all PR types
- Update `docs/RELEASE.md` Stable Release Workflow with merge commit requirement and rationale

## Test plan

- [ ] CI passes
- [ ] CLAUDE.md and docs/RELEASE.md render correctly