### PR TITLE
chore: pin GitHub Actions to commit SHAs and lock tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
       matrix:
         go-version: ["1.21", "1.22"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
       - run: go vet ./...
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
-          version: latest
+          version: v1.64.8
       - run: go build ./...
       - run: go test -count=1 -race -coverprofile=coverage.out ./...
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         if: matrix.go-version == '1.22'
         with:
           files: coverage.out

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,16 @@ jobs:
     if: github.repository == 'jrrembert/go-luhn'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-      - run: npx semantic-release
+      - run: npx semantic-release@24.2.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.21'
       - name: Register with Go module proxy


### PR DESCRIPTION
## Summary

Harden the CI/CD supply chain by pinning all GitHub Actions to immutable commit SHAs and locking tool versions.

Closes #55

## Changes

- Pin all GitHub Actions to full commit SHAs with version comments in `ci.yml`, `release.yml`, `pr-title.yml`
- Pin `golangci-lint` binary to `v1.64.8` (was `latest`)
- Pin `semantic-release` to `@24.2.9` (was unpinned `npx semantic-release`)

## Test plan

- [ ] CI passes with pinned action SHAs
- [ ] `golangci-lint` runs at `v1.64.8`
- [ ] PR title validation still works