### PR TITLE
docs: add Go Reference and Go Report Card badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/jrrembert/go-luhn/actions/workflows/ci.yml/badge.svg)](https://github.com/jrrembert/go-luhn/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/jrrembert/go-luhn/graph/badge.svg)](https://codecov.io/gh/jrrembert/go-luhn)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jrrembert/go-luhn.svg)](https://pkg.go.dev/github.com/jrrembert/go-luhn)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jrrembert/go-luhn)](https://goreportcard.com/report/github.com/jrrembert/go-luhn)
 
 A Go implementation of the Luhn algorithm for generating and validating checksums.
 


### PR DESCRIPTION
## Summary

Add Go Reference (pkg.go.dev) and Go Report Card badges to the README to signal quality and improve discoverability.

Closes #64

## Changes

- Add Go Reference badge linking to pkg.go.dev
- Add Go Report Card badge linking to goreportcard.com

## Test plan

- [x] Badge URLs are correct and resolve to the right pages
- [x] No other README content changed