### PR TITLE
docs: add inline comments explaining constant-time comparison

### DIFF
--- a/luhn.go
+++ b/luhn.go
@@ -104,6 +104,8 @@ func Validate(value string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// Use constant-time comparison to prevent timing side-channel attacks
+	// that could reveal information about valid check digits.
 	return subtle.ConstantTimeCompare([]byte(generated), []byte(value)) == 1, nil
 }
 
@@ -241,6 +243,8 @@ func ValidateModN(value string, n int) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// Use constant-time comparison to prevent timing side-channel attacks
+	// that could reveal information about valid check digits.
 	return subtle.ConstantTimeCompare([]byte(generated), []byte(value)) == 1, nil
 }
 


### PR DESCRIPTION
## Summary

Add inline doc comments explaining why `subtle.ConstantTimeCompare` is used instead of `==` in `Validate` and `ValidateModN`.

Closes #69

## Changes

- Add comment above `subtle.ConstantTimeCompare` in `Validate` explaining timing side-channel prevention
- Add same comment in `ValidateModN`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)