### PR TITLE
chore: recreate copyright date update workflow

### DIFF
--- a/.github/workflows/update-copyright-date.yml
+++ b/.github/workflows/update-copyright-date.yml
@@ -1,0 +1,30 @@
+name: Update copyright date
+
+on:
+  schedule:
+    - cron: "0 0 1 1 *" # January 1st at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-copyright:
+    if: github.repository == 'jrrembert/go-luhn'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Update copyright years
+        run: bash update-copyright-date.sh
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          commit-message: "chore: update copyright year"
+          title: "chore: update copyright year"
+          body: |
+            Automated annual copyright year update.
+
+            Updates copyright year ranges in LICENSE and README.md.
+          branch: chore/update-copyright-date
+          delete-branch: true


### PR DESCRIPTION
## Summary

Recreate the copyright date update workflow that was removed in #56 due to security issues. The new version follows project standards.

Closes #68

## Changes

- Create `.github/workflows/update-copyright-date.yml` with SHA-pinned actions
- Uses `peter-evans/create-pull-request` to open a PR instead of pushing directly to `main`
- Runs annually on Jan 1st at midnight UTC, with manual `workflow_dispatch` trigger
- Fork protection via `if: github.repository == 'jrrembert/go-luhn'`
- Update `update-copyright-date.sh` to handle both `Copyright (c)` (LICENSE) and `©` (README.md) patterns
- Script now reports which files were updated vs already current

## Test plan

- [ ] CI passes
- [ ] Manual `workflow_dispatch` trigger creates a PR with correct copyright year updates
- [ ] Verify script handles both LICENSE and README.md copyright formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)