### PR TITLE
ci: auto-merge release PRs with merge commit strategy

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,20 @@
+name: Auto-merge release PRs
+
+on:
+  pull_request:
+    types: [opened]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.repository == 'jrrembert/go-luhn' && github.head_ref == 'rc'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge with merge commit
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Releases are fully automated via [semantic-release](https://github.com/semantic-
 - Always merge PRs via GitHub UI or `gh pr merge` — never merge locally with `git merge` then push. Local merges break GitHub's `Closes #N` auto-close linking.
 - **Merge strategy**:
   - `--rebase` for all regular PRs: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `ci:`
-  - `--merge` (merge commit) for release PRs (`rc` → `main`) — keeps the branches in sync and avoids SHA divergence
+  - `--merge` (merge commit) for release PRs (`rc` → `main`) — keeps the branches in sync and avoids SHA divergence. This is enforced automatically: when a release PR from `rc` to `main` is opened, the `auto-merge-release.yml` workflow enables auto-merge with `--merge`
 - PRs use the template at `.github/PULL_REQUEST_TEMPLATE.md` — fill in all sections (Summary, Changes, Test plan)
 - Use `/pr` or `/pr <issue-number>` to create pull requests with the standard format
 - Always create the feature branch from the appropriate base branch (`rc` for features/fixes, `main` for chore/docs) **before** writing code, not at commit time

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,6 +31,8 @@ When `rc` is merged into `main`, semantic-release:
 
 **Important**: Release PRs (`rc` → `main`) must use **merge commits** (`gh pr merge --merge`), not rebase. Rebase replays commits with new SHAs, causing `rc` and `main` to diverge and requiring a sync step after every release. Merge commits preserve the shared history between branches.
 
+This is enforced automatically by `.github/workflows/auto-merge-release.yml` — when a PR from `rc` to `main` is opened, the workflow enables GitHub auto-merge with the merge commit strategy. Once all required status checks pass, the PR merges automatically.
+
 
 Go module consumers can then install the stable version:
 


### PR DESCRIPTION
## Summary

Add a workflow that enforces merge commit strategy for release PRs (`rc` → `main`). When a release PR is opened, the workflow automatically enables GitHub auto-merge with `--merge`, preventing accidental rebase merges that cause SHA divergence between branches.

**Context**: v1.0.0 was released with `--rebase` instead of `--merge`, creating duplicate commit SHAs. When `rc` was later merged into `main`, semantic-release saw the original SHAs as new `feat:` commits and bumped to v1.1.0 instead of v1.0.1.

Closes #76

## Changes

- Add `.github/workflows/auto-merge-release.yml` — enables auto-merge with `--merge` when a PR from `rc` to `main` is opened
- Enable repo-level auto-merge setting (already done via API)
- Update `CLAUDE.md` merge strategy section to document the enforcement
- Update `docs/RELEASE.md` stable release section to document the automation

## Test plan

- [ ] CI passes
- [ ] Verify workflow triggers correctly on next release PR from `rc` to `main`