### PR TITLE
ci: add automated post-release rc sync workflow

### DIFF
--- a/.github/workflows/sync-rc.yml
+++ b/.github/workflows/sync-rc.yml
@@ -1,0 +1,85 @@
+name: Sync rc with main
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+    branches: [rc]
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  # After any push to rc, mark sync status as success (unblocks PRs)
+  clear-sync-status:
+    if: github.repository == 'jrrembert/go-luhn' && github.ref == 'refs/heads/rc'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: rc
+      - name: Set sync status to success
+        run: |
+          SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            -f state=success \
+            -f context=sync/rc-up-to-date \
+            -f description="rc is up to date with main"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # After a stable release tag, sync rc with main
+  sync:
+    if: github.repository == 'jrrembert/go-luhn' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: rc
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Block PRs to rc during sync
+        run: |
+          SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            -f state=pending \
+            -f context=sync/rc-up-to-date \
+            -f description="Syncing rc with main after release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attempt merge
+        id: merge
+        run: |
+          git fetch origin main
+          if git merge origin/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push clean merge
+        if: steps.merge.outputs.conflict == 'false'
+        run: git push origin HEAD:rc
+
+      - name: Create sync PR for manual conflict resolution
+        if: steps.merge.outputs.conflict == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          branch: chore/sync-rc-after-release
+          base: rc
+          title: "chore: sync rc with main after release"
+          body: |
+            Automated post-release sync. This PR merges `main` into `rc`.
+
+            **This PR has merge conflicts that need manual resolution.**
+
+            All other PRs targeting `rc` are blocked until this sync completes.
+          delete-branch: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Releases are fully automated via [semantic-release](https://github.com/semantic-
 - **Merge strategy**:
   - `--rebase` for all regular PRs: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `ci:`
   - `--merge` (merge commit) for release PRs (`rc` → `main`) — keeps the branches in sync and avoids SHA divergence. This is enforced automatically: when a release PR from `rc` to `main` is opened, the `auto-merge-release.yml` workflow enables auto-merge with `--merge`
+- **Post-release sync**: After each stable release, `sync-rc.yml` automatically merges `main` into `rc`. If conflicts arise, a sync PR is created and all PRs to `rc` are blocked until it's resolved
 - PRs use the template at `.github/PULL_REQUEST_TEMPLATE.md` — fill in all sections (Summary, Changes, Test plan)
 - Use `/pr` or `/pr <issue-number>` to create pull requests with the standard format
 - Always create the feature branch from the appropriate base branch (`rc` for features/fixes, `main` for chore/docs) **before** writing code, not at commit time

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -109,6 +109,27 @@ To test what semantic-release would do without creating a release:
 npx semantic-release --dry-run
 ```
 
+## Post-release sync
+
+After each stable release, `rc` must be synced with `main` to pick up any `chore:`/`docs:` commits that targeted `main` directly. This is automated by `.github/workflows/sync-rc.yml`.
+
+### How it works
+
+1. A stable release tag (e.g., `v1.1.0`) triggers the `sync` job
+2. The workflow sets a `sync/rc-up-to-date` commit status to **pending** on `rc`'s HEAD, blocking all PRs to `rc` via branch protection
+3. It attempts to merge `main` into `rc`
+4. **If clean merge**: pushes directly to `rc`. The push triggers the `clear-sync-status` job, which sets the status to **success**, unblocking PRs
+5. **If conflicts**: creates a sync PR (`chore/sync-rc-after-release` → `rc`) for manual resolution. PRs to `rc` remain blocked until the sync PR is merged
+
+### Manual conflict resolution
+
+If the sync PR has conflicts:
+
+1. Check out the `chore/sync-rc-after-release` branch locally
+2. Resolve conflicts, commit, and push
+3. Merge the sync PR — this pushes to `rc`, triggering the `clear-sync-status` job
+4. Verify the `sync/rc-up-to-date` status is **success** on `rc`'s HEAD
+
 ## Troubleshooting
 
 ### No release was created


### PR DESCRIPTION
## Summary

After each stable release, automatically merge `main` into `rc` to pick up `chore:`/`docs:` commits that targeted `main` directly. Blocks PRs to `rc` during sync to prevent race conditions.

Closes #78

## Changes

- Add `.github/workflows/sync-rc.yml` with two jobs:
  - `clear-sync-status`: triggers on push to `rc`, sets `sync/rc-up-to-date` status to success (unblocks PRs)
  - `sync`: triggers on stable version tags, sets status to pending (blocks PRs), attempts merge, pushes directly or creates a conflict-resolution PR
- Add `sync/rc-up-to-date` as a required status check on `rc` branch protection (already applied via API)
- Set initial status to success on current `rc` HEAD (so existing PRs aren't blocked)
- Update `docs/RELEASE.md` with post-release sync section
- Update `CLAUDE.md` with post-release sync note in Git Workflow

## Test plan

- [x] `sync/rc-up-to-date` status is success on current `rc` HEAD
- [x] `rc` branch protection requires `sync/rc-up-to-date` check
- [ ] CI passes
- [ ] Verify workflow triggers on next stable release tag