### PR TITLE
fix: add shared input validation to mod-N functions

### DIFF
--- a/luhn.go
+++ b/luhn.go
@@ -151,6 +151,24 @@ func Random(length string) (string, error) {
 	return result, nil
 }
 
+// validateModNInput validates input for mod-N functions.
+// Checks empty and spaces (shared with validateInput), then validates each
+// character against the CODE_POINTS alphabet for the given n.
+func validateModNInput(value string, n int) error {
+	if value == "" {
+		return errEmpty
+	}
+	if strings.Contains(value, " ") {
+		return errSpaces
+	}
+	for i := 0; i < len(value); i++ {
+		if charIndex(value[i], n) < 0 {
+			return fmt.Errorf("invalid character: %q", value[i])
+		}
+	}
+	return nil
+}
+
 // charIndex returns the index of c in the CODE_POINTS alphabet, or -1 if not found.
 func charIndex(c byte, n int) int {
 	var idx int
@@ -200,11 +218,11 @@ func generateChecksumModN(value string, n int) (int, error) {
 // GenerateModN computes a Luhn mod-N check character for the given alphanumeric value.
 // n must be between 1 and 36. If checksumOnly is true, only the check character is returned.
 func GenerateModN(value string, n int, checksumOnly bool) (string, error) {
-	if value == "" {
-		return "", errEmpty
-	}
 	if n < 1 || n > 36 {
 		return "", errInvalidN
+	}
+	if err := validateModNInput(value, n); err != nil {
+		return "", err
 	}
 	if len(value) >= 10000 {
 		return "", errModNMaxLength
@@ -225,14 +243,14 @@ func GenerateModN(value string, n int, checksumOnly bool) (string, error) {
 // ValidateModN determines whether value has a valid Luhn mod-N check character.
 // n must be between 1 and 36.
 func ValidateModN(value string, n int) (bool, error) {
-	if value == "" {
-		return false, errEmpty
+	if n < 1 || n > 36 {
+		return false, errInvalidN
+	}
+	if err := validateModNInput(value, n); err != nil {
+		return false, err
 	}
 	if len(value) == 1 {
 		return false, errMinLength
-	}
-	if n < 1 || n > 36 {
-		return false, errInvalidN
 	}
 	if len(value) >= 10000 {
 		return false, errModNMaxLength
@@ -251,11 +269,11 @@ func ValidateModN(value string, n int) (bool, error) {
 // ChecksumModN returns the integer index of the Luhn mod-N check character for value.
 // n must be between 1 and 36.
 func ChecksumModN(value string, n int) (int, error) {
-	if value == "" {
-		return 0, errEmpty
-	}
 	if n < 1 || n > 36 {
 		return 0, errInvalidN
+	}
+	if err := validateModNInput(value, n); err != nil {
+		return 0, err
 	}
 	if len(value) >= 10000 {
 		return 0, errModNMaxLength


### PR DESCRIPTION
## Summary

Add a dedicated `validateModNInput()` routine so that mod-N functions (`GenerateModN`, `ValidateModN`, `ChecksumModN`) produce consistent, clear error messages instead of falling through to generic `charIndex` errors.

Closes #82

## Changes

- Add `validateModNInput(value, n)` that checks empty, spaces, then validates each character against `CODE_POINTS` for the given `n`
- Apply it in `GenerateModN`, `ValidateModN`, and `ChecksumModN` — replacing the ad-hoc empty checks
- `ValidateModN` now validates the **entire** input (including the check character position) before processing, fixing `ValidateModN("1a", 10)` returning `(false, nil)` instead of an error
- Spaces produce the clear `"string cannot contain spaces"` error (shared with base functions) instead of `"invalid character: ' '"`
- Characters like `-` and `.` correctly produce `"invalid character: ..."` in mod-N context (legit divergence from base functions where they trigger numeric-specific messages)
- Update SPEC.md §4 with a new "Mod-N Input Validation" subsection documenting the validation order and the rationale for divergence from base validation
- Add mod-N error test vectors to SPEC.md §5

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] New tests verify spaces, dashes, dots, special chars, and out-of-range chars for all three mod-N functions
- [x] New test verifies `ValidateModN("1a", 10)` now returns an error (was silently `(false, nil)`)
- [x] New test verifies validation order (spaces before per-character)
- [x] All existing tests continue to pass (no regressions)