### PR TITLE
chore: sync rc with main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,12 @@ Releases are fully automated via [semantic-release](https://github.com/semantic-
   - `--rebase` for all regular PRs: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `ci:`
   - `--merge` (merge commit) for release PRs (`rc` → `main`) — keeps the branches in sync and avoids SHA divergence. This is enforced automatically: when a release PR from `rc` to `main` is opened, the `auto-merge-release.yml` workflow enables auto-merge with `--merge`
 - **Post-release sync**: After each stable release, `sync-rc.yml` automatically merges `main` into `rc`. If conflicts arise, a sync PR is created and all PRs to `rc` are blocked until it's resolved
+- **`sync/rc-up-to-date` status check**: Required on `rc`. Only set automatically by the sync workflow after a release. For the first PR to `rc` after a fresh sync (or if the status is missing), you may need to set it manually:
+  ```bash
+  gh api repos/jrrembert/go-luhn/statuses/$(git rev-parse HEAD) \
+    -f state=success -f context="sync/rc-up-to-date" \
+    -f description="rc is up to date with main"
+  ```
 - PRs use the template at `.github/PULL_REQUEST_TEMPLATE.md` — fill in all sections (Summary, Changes, Test plan)
 - Use `/pr` or `/pr <issue-number>` to create pull requests with the standard format
 - Always create the feature branch from the appropriate base branch (`rc` for features/fixes, `main` for chore/docs) **before** writing code, not at commit time


### PR DESCRIPTION
## Summary

Sync rc with main after docs commit (PR #85) landed directly on main.

## Changes

- Merge main into rc to pick up CLAUDE.md documentation update

## Test plan

- [x] Merge conflict resolved (CLAUDE.md only)
- [x] No code changes, docs only