### PR TITLE
fix: normalize input to uppercase in ValidateModN

### DIFF
--- a/luhn.go
+++ b/luhn.go
@@ -256,14 +256,18 @@ func ValidateModN(value string, n int) (bool, error) {
 		return false, errModNMaxLength
 	}
 
-	payload := value[:len(value)-1]
+	// Normalize to uppercase so that lowercase input matches the uppercase
+	// CODE_POINTS alphabet used by GenerateModN.
+	upper := strings.ToUpper(value)
+
+	payload := upper[:len(upper)-1]
 	generated, err := GenerateModN(payload, n, false)
 	if err != nil {
 		return false, err
 	}
 	// Use constant-time comparison to prevent timing side-channel attacks
 	// that could reveal information about valid check digits.
-	return subtle.ConstantTimeCompare([]byte(generated), []byte(value)) == 1, nil
+	return subtle.ConstantTimeCompare([]byte(generated), []byte(upper)) == 1, nil
 }
 
 // ChecksumModN returns the integer index of the Luhn mod-N check character for value.

--- a/luhn_test.go
+++ b/luhn_test.go
@@ -466,6 +466,50 @@ func TestValidateModN_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestValidateModN_CaseInsensitive tests that ValidateModN accepts lowercase check characters.
+func TestValidateModN_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		n     int
+	}{
+		{"lowercase check char", "hello", 36},
+		{"uppercase check char", "HELLO", 36},
+		{"mixed case payload", "HeLLo", 36},
+		{"hex lowercase", "ff", 16},
+		{"hex uppercase", "FF", 16},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Generate the correct value (always uppercase check char)
+			generated, err := luhn.GenerateModN(tt.input, tt.n, false)
+			if err != nil {
+				t.Fatalf("GenerateModN error: %v", err)
+			}
+
+			// Uppercase version should validate
+			valid, err := luhn.ValidateModN(generated, tt.n)
+			if err != nil {
+				t.Fatalf("ValidateModN(%q) error: %v", generated, err)
+			}
+			if !valid {
+				t.Errorf("ValidateModN(%q, %d) = false, want true", generated, tt.n)
+			}
+
+			// Lowercase version should also validate
+			lowered := strings.ToLower(generated)
+			valid, err = luhn.ValidateModN(lowered, tt.n)
+			if err != nil {
+				t.Fatalf("ValidateModN(%q) error: %v", lowered, err)
+			}
+			if !valid {
+				t.Errorf("ValidateModN(%q, %d) = false, want true [lowercased]", lowered, tt.n)
+			}
+		})
+	}
+}
+
 // TestValidateModN_Invalid tests that wrong check characters are rejected.
 func TestValidateModN_Invalid(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fix `ValidateModN` rejecting valid lowercase check characters by normalizing input to uppercase before comparison.

Closes #81

## Changes

- Normalize `value` to uppercase in `ValidateModN` before stripping the check character and comparing against `GenerateModN` output (which always uses uppercase CODE_POINTS)
- Add `TestValidateModN_CaseInsensitive` covering lowercase check chars, uppercase, mixed case, and hex variants

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] New test verifies lowercase, uppercase, and mixed case inputs all validate correctly
- [x] Existing tests continue to pass (no regressions)